### PR TITLE
Various fixes for the bottom sheet.

### DIFF
--- a/app/src/main/java/org/refugerestrooms/views/MainActivity.java
+++ b/app/src/main/java/org/refugerestrooms/views/MainActivity.java
@@ -27,6 +27,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -198,6 +199,9 @@ public class MainActivity extends AppCompatActivity
     private int location_count;
     // Create hashmap to store bathrooms (Key = LatLng, Value = Bathroom)
     private final Map<LatLng, Bathroom> allBathroomsMap = new HashMap<>();
+
+    private Fragment addBathroomFragment;
+    private FragmentManager fragmentManager;
 
     // Define a DialogFragment that displays the error dialog
     public static class ErrorDialogFragment extends DialogFragment {
@@ -472,6 +476,29 @@ public class MainActivity extends AppCompatActivity
         comments.setText(Html.fromHtml(bathroom.getCommentsFormatted()));
         View specsView = findViewById(R.id.specs);
         BathroomSpecsViewUpdater.update(specsView, bathroom, this);
+
+        // Change text padding to center in the bottom sheet peek.
+        int lineCount = title.getLineCount();
+        if (lineCount == 1) {
+            // Single displayed line padding
+            title.setPadding(title.getPaddingLeft(),
+                    getResources().getDimensionPixelOffset(R.dimen.one_line_padding),
+                    title.getPaddingRight(),
+                    title.getPaddingBottom());
+        } else if (lineCount == 2) {
+            // Two displayed line padding
+            title.setPadding(title.getPaddingLeft(),
+                    getResources().getDimensionPixelOffset(R.dimen.two_line_padding),
+                    title.getPaddingRight(),
+                    title.getPaddingBottom());
+        } else {
+            // Else 0 top padding
+            title.setPadding(title.getPaddingLeft(),
+                    getResources().getDimensionPixelOffset(R.dimen.zero_padding),
+                    title.getPaddingRight(),
+                    title.getPaddingBottom());
+        }
+
         findViewById(R.id.button_maps).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -584,6 +611,14 @@ public class MainActivity extends AppCompatActivity
 
         NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
+
+        // Create an instance of the bathroom fragment to pre-load the website into the cache.
+        // Swap this instance in later when selected.
+        addBathroomFragment = new AddBathroomFragment();
+        fragmentManager = getSupportFragmentManager();
+        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+        fragmentTransaction.attach(addBathroomFragment);
+        fragmentTransaction.commit();
 
         bottomSheet = findViewById(R.id.bottom_info_sheet);
 
@@ -1399,7 +1434,6 @@ public class MainActivity extends AppCompatActivity
         // Handle navigation view item clicks here.
         int id = item.getItemId();
 
-        FragmentManager fragmentManager = getSupportFragmentManager();
         Fragment fragment = null;
         String title = null;
         String fragmentTitle = null;
@@ -1420,7 +1454,6 @@ public class MainActivity extends AppCompatActivity
             bottomSheet.setVisibility(View.VISIBLE);
         } else if (id == R.id.nav_add) {
             title = getString(R.string.add_title_section);
-            fragment = new AddBathroomFragment();
             fragmentTitle = "addBathroom";
             mFab.show();
             bottomSheet.setVisibility(View.INVISIBLE);
@@ -1435,6 +1468,12 @@ public class MainActivity extends AppCompatActivity
         if (fragment != null) {
             fragmentManager.beginTransaction()
                     .replace(R.id.container, fragment)
+                    .addToBackStack(fragmentTitle)
+                    .commit();
+            setToolbarTitle(title);
+        } else {
+            fragmentManager.beginTransaction()
+                    .replace(R.id.container, addBathroomFragment)
                     .addToBackStack(fragmentTitle)
                     .commit();
             setToolbarTitle(title);

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,30 +38,45 @@
 
         </android.support.design.widget.AppBarLayout>
 
-        <include layout="@layout/content_main" />
-
-        <android.support.v4.widget.NestedScrollView
-            android:id="@+id/bottom_info_sheet"
+        <include layout="@layout/content_main"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@android:color/white"
-            app:layout_behavior="android.support.design.widget.BottomSheetBehavior"
-            app:behavior_peekHeight="72dp">
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
-            <include layout="@layout/bottom_sheet_details" />
+        <android.support.design.widget.CoordinatorLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        </android.support.v4.widget.NestedScrollView>
+            <android.support.v4.widget.NestedScrollView
+                android:id="@+id/bottom_info_sheet"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/white"
+                app:behavior_peekHeight="72dp"
+                app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
 
+                <include layout="@layout/bottom_sheet_details" />
+
+            </android.support.v4.widget.NestedScrollView>
+
+        </android.support.design.widget.CoordinatorLayout>
+
+
+        <!-- Adjusted margins on FAB to prevent it from blocking the title. -->
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|right|end"
-            android:layout_margin="@dimen/fab_margin"
+            android:layout_marginBottom="60dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginLeft="16dp"
             android:src="@drawable/ic_directions_white_24dp"
             app:fabSize="normal"
             app:layout_anchor="@id/bottom_info_sheet"
             app:layout_anchorGravity="top|right|end" />
+            <!-- android:layout_margin="@dimen/fab_margin" -->
 
     </android.support.design.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/bottom_sheet_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_details.xml
@@ -2,13 +2,15 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/text_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="12dp"
+        android:paddingBottom="14dp"
+        android:paddingLeft="15dp"
+        android:paddingRight="15dp"
         android:gravity="center"
         android:textColor="@color/ColorHeader"
         android:textIsSelectable="true"
@@ -64,5 +66,6 @@
         android:textIsSelectable="true"
         android:textSize="16sp"
         android:paddingBottom="12dp"
+
         tools:text="\nDirections\n\nNo directions at this time.\n\n\nComments\n\nNo comments at this time.\n" />
 </RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,5 +3,10 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
 
+    <!-- Different padding dimensions for text displayed in the bottom sheet peek. -->
+    <dimen name="one_line_padding">22dp</dimen>
+    <dimen name="two_line_padding">11dp</dimen>
+    <dimen name="zero_padding">0dp</dimen>
+
     <dimen name="fab_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
- Fixed issues with the bottom sheet overlapping the app bar.
- The titles of bathooms now stay centered in the bottom sheet while collapsed (while <= 3 lines long).
- The FAB no longer blocks far-right letters on certain long titles.

This still needs to be tested on more displays and in more scenarios. It works on my phone and several emulated android devices in both portrait and landscape, though the emulated devices were all relatively new.

Up to and including bathroom titles 3 lines long it doesn't seem to have issues. Some clipping will occur with bathroom titles over 4 lines long, however fixing this would do more harm than good (extremely long bathroom titles could block the entire view from the user if the peek height were dynamically set).